### PR TITLE
Collapse's isOpen is now in, collapse do not accept display

### DIFF
--- a/apps/courses/src/components/Cookies.tsx
+++ b/apps/courses/src/components/Cookies.tsx
@@ -43,12 +43,16 @@ export default ({ callback }) => {
         >
           Click me for {isOpen ? 'less' : 'more'} information
         </Text>
-        <Collapse
-          in={isOpen}
-          animateOpacity
+        <Box
+          display={{ base: 'block', md: 'none' }}
         >
-          <Justification />
-        </Collapse>
+          <Collapse
+            in={isOpen}
+            animateOpacity
+          >
+            <Justification />
+          </Collapse>
+        </Box>
         <Justification
           display={{ base: 'none', md: 'block' }}
           width={{ lg: '80%' }}

--- a/apps/courses/src/components/Cookies.tsx
+++ b/apps/courses/src/components/Cookies.tsx
@@ -44,9 +44,8 @@ export default ({ callback }) => {
           Click me for {isOpen ? 'less' : 'more'} information
         </Text>
         <Collapse
-          isOpen={isOpen}
+          in={isOpen}
           animateOpacity
-          display={{ base: 'block', md: 'none' }}
         >
           <Justification />
         </Collapse>


### PR DESCRIPTION
## Description
Collapse properties were changed. isOpen is now changed to in and do not accept display prop.


## Affected Dependencies
No

## How has this been tested?

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
