### PR TITLE
Move header and footer config to a RouteWrapper

### DIFF
--- a/apps/courses/src/App.tsx
+++ b/apps/courses/src/App.tsx
@@ -11,11 +11,8 @@ import {
 
 import Routes from './routes';
 
-import Header from './components/Header';
 import Loading from './components/Loading';
 import Cookies from './components/Cookies';
-import Footer from './components/Footer';
-import { Box } from '@chakra-ui/react';
 
 import { SuspenseWithPerf } from 'reactfire';
 
@@ -82,28 +79,6 @@ const App = () => {
     setCookiePrefs(preference);
   };
 
-  // SEE TODO (#1)
-
-  // If we're inside the course, don't show the <Header /> at all
-  // Instead, we'll show the <CourseHeader />
-  const isInsideCourse =
-    location.pathname.includes('/courses') &&
-    location.pathname.split('/').length > 3 &&
-    !location.pathname.includes('/complete');
-
-  // If we're on the course completion page, we want the header to default to black
-  const isOnCourseComplete =
-    location.pathname.includes('/courses') &&
-    location.pathname.split('/').length > 3 &&
-    location.pathname.includes('/complete');
-
-  // If we're inside the concept, we don't render the default <Footer />
-  // Instead, we'll show the <CourseFooter />
-  const isInsideConcept =
-    location.pathname.includes('/courses') &&
-    location.pathname.split('/').length > 4 &&
-    !location.pathname.includes('/project');
-
   // const firebaseApp = useFirebaseApp();
 
   // if (process.env.NODE_ENV === 'development') {
@@ -114,15 +89,7 @@ const App = () => {
     <Router action={action} location={location} navigator={history}>
       <SuspenseWithPerf fallback={<Loading />} traceId={location.pathname}>
         {cookiePrefs === 'all' && <Analytics location={location} />}
-        {!isInsideCourse && <Header noScrolling={isOnCourseComplete} />}
-        <Box
-          minHeight="100vh"
-          display="grid"
-          gridTemplateRows={isInsideConcept ? '1fr' : '1fr auto'}
-        >
-          <Routes />
-          {!isInsideConcept && <Footer />}
-        </Box>
+        <Routes />
         {!cookiePrefs && <Cookies callback={storeCookiePrefs} />}
       </SuspenseWithPerf>
     </Router>

--- a/apps/courses/src/TODO.md
+++ b/apps/courses/src/TODO.md
@@ -12,9 +12,8 @@ We need to have the following items FINISHED BY LAUNCH on December 31st, 2020.
 - We have a ton of problems with network requests and race conditions. For instance, signing up will redirect to the profile page where your name is empty. If you refresh the page, your name shows up. This type of behavior is present on basically every single page and is why we use window.location.href in a lot of places. It would be better to rely on client-side navigation if we could ensure that all rendering logic properly waited for the appropriate network requests to load. Can we implement this?
 - Add a ton of Cypress tests
 
-### Thiago
+### SLZ
 
-- TODO (#1): Define configuration for main routes file to determine which routes receive the main header and main footer. Have this done in an RouteWrapper component where you can pass the appropriate props for each route.
 - TODO (#3): Create a custom `<Icon />` component that automates the `as` prop and also prefers the sizing of the Chakra theme using `boxSize` instead of the `size` props provided by React-FontAwesome. Convert all icons to use this custom component and then swap out their `size` for the appropriate `boxSize` in Chakra.
 - TODO (#4): All radios and checkboxes require a double click for some reason... have no idea what's going on here, but Chakra doesn't natively have this problem. It's something we're doing wrong here.
 - TODO (#5): Centralize Github provider logic - currently, every time we need to do something with Github as a sign in/up provider, we have to define it as a provider AND list the scope. If the scope is changed in one file, and not another... this could have very bad consequences. Centralize this logic somehow and use it throughout.

--- a/apps/courses/src/routes/index.tsx
+++ b/apps/courses/src/routes/index.tsx
@@ -2,6 +2,11 @@ import React, { lazy } from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 import { useUser } from 'reactfire';
 
+import { Box } from '@chakra-ui/react';
+
+import Header from '../components/Header';
+import Footer from '../components/Footer';
+
 const Homepage = lazy(() => import('./homepage'));
 const Signup = lazy(() => import('./users/sign-up'));
 const Signin = lazy(() => import('./users/sign-in'));
@@ -24,54 +29,192 @@ const UnauthRoute = (props) => {
   return !user ? <Route {...props} /> : <Navigate to="/users/dashboard" />;
 };
 
+const RouteWrapper = ({
+  noHeader = false,
+  noFooter = false,
+  blackHeader = false,
+  inConcept = false,
+  children,
+}) => (
+  <>
+    {!noHeader && <Header noScrolling={blackHeader} />}
+    <Box
+      minHeight="100vh"
+      display="grid"
+      gridTemplateRows={!inConcept ? '1fr' : '1fr auto'}
+    >
+      {children}
+      {!noFooter && <Footer />}
+    </Box>
+  </>
+);
+
 export default () => (
   <Routes>
-    <Route path="/" element={<Homepage />} />
-    <UnauthRoute path="signup" element={<Signup />} />
-    <UnauthRoute path="signin" element={<Signin />} />
+    <Route
+      path="/"
+      element={
+        <RouteWrapper>
+          <Homepage />
+        </RouteWrapper>
+      }
+    />
+    <UnauthRoute
+      path="signup"
+      element={
+        <RouteWrapper>
+          <Signup />
+        </RouteWrapper>
+      }
+    />
+    <UnauthRoute
+      path="signin"
+      element={
+        <RouteWrapper>
+          <Signin />
+        </RouteWrapper>
+      }
+    />
     <Route path="users">
       <Route path="/" element={<Navigate to="/" />} />
-      <AuthRoute path="dashboard" element={<Dashboard />} />
-      <AuthRoute path="settings" element={<Settings />} />
-      <Route path=":uid" element={<Profile />} />
+      <AuthRoute
+        path="dashboard"
+        element={
+          <RouteWrapper>
+            <Dashboard />
+          </RouteWrapper>
+        }
+      />
+      <AuthRoute
+        path="settings"
+        element={
+          <RouteWrapper>
+            <Settings />
+          </RouteWrapper>
+        }
+      />
+      <Route
+        path=":uid"
+        element={
+          <RouteWrapper>
+            <Profile />
+          </RouteWrapper>
+        }
+      />
     </Route>
     <Route path="courses">
-      <Route path="/" element={<CoursePage which="search" />} />
+      <Route
+        path="/"
+        element={
+          <RouteWrapper>
+            <CoursePage which="search" />
+          </RouteWrapper>
+        }
+      />
       <Route path=":course">
-        <Route path="/" element={<CoursePage which="overview" />} />
+        <Route
+          path="/"
+          element={
+            <RouteWrapper>
+              <CoursePage which="overview" />
+            </RouteWrapper>
+          }
+        />
         <AuthRoute
           path="complete"
-          element={<CoursePage which="courseComplete" />}
+          element={
+            <RouteWrapper blackHeader>
+              <CoursePage which="courseComplete" />
+            </RouteWrapper>
+          }
         />
         <AuthRoute path="project">
-          <AuthRoute path="/" element={<CoursePage which="project" />} />
+          <AuthRoute
+            path="/"
+            element={
+              <RouteWrapper noHeader>
+                <CoursePage which="project" />
+              </RouteWrapper>
+            }
+          />
           <AuthRoute
             path="complete"
-            element={<CoursePage which="projectComplete" />}
+            element={
+              <RouteWrapper blackHeader noFooter>
+                <CoursePage which="projectComplete" />
+              </RouteWrapper>
+            }
           />
           <AuthRoute path=":part">
             <AuthRoute
               path="/"
-              element={<CoursePage which="projectSubmission" />}
+              element={
+                <RouteWrapper noHeader>
+                  <CoursePage which="projectSubmission" />
+                </RouteWrapper>
+              }
             />
             <AuthRoute
               path=":attempt"
-              element={<CoursePage which="projectSubmission" />}
+              element={
+                <RouteWrapper noHeader>
+                  <CoursePage which="projectSubmission" />
+                </RouteWrapper>
+              }
             />
           </AuthRoute>
         </AuthRoute>
         <AuthRoute path=":lesson">
-          <AuthRoute path="/" element={<CoursePage which="lesson" />} />
+          <AuthRoute
+            path="/"
+            element={
+              <RouteWrapper noHeader>
+                <CoursePage which="lesson" />
+              </RouteWrapper>
+            }
+          />
           <AuthRoute
             path="complete"
-            element={<CoursePage which="lessonComplete" />}
+            element={
+              <RouteWrapper blackHeader inConcept noFooter>
+                <CoursePage which="lessonComplete" />
+              </RouteWrapper>
+            }
           />
-          <AuthRoute path=":concept" element={<CoursePage which="concept" />} />
+          <AuthRoute
+            path=":concept"
+            element={
+              <RouteWrapper noHeader inConcept noFooter>
+                <CoursePage which="concept" />
+              </RouteWrapper>
+            }
+          />
         </AuthRoute>
       </Route>
     </Route>
-    <Route path="policy" element={<PolicyAndTerms />} />
-    <Route path="terms" element={<PolicyAndTerms />} />
-    <Route path="*" element={<NoMatch />} />
+    <Route
+      path="policy"
+      element={
+        <RouteWrapper>
+          <PolicyAndTerms />
+        </RouteWrapper>
+      }
+    />
+    <Route
+      path="terms"
+      element={
+        <RouteWrapper>
+          <PolicyAndTerms />
+        </RouteWrapper>
+      }
+    />
+    <Route
+      path="*"
+      element={
+        <RouteWrapper>
+          <NoMatch />
+        </RouteWrapper>
+      }
+    />
   </Routes>
 );

--- a/apps/courses/src/routes/index.tsx
+++ b/apps/courses/src/routes/index.tsx
@@ -31,9 +31,8 @@ const UnauthRoute = (props) => {
 
 const RouteWrapper = ({
   noHeader = false,
-  noFooter = false,
   blackHeader = false,
-  inConcept = false,
+  noFooter = false,
   children,
 }) => (
   <>
@@ -41,7 +40,7 @@ const RouteWrapper = ({
     <Box
       minHeight="100vh"
       display="grid"
-      gridTemplateRows={!inConcept ? '1fr' : '1fr auto'}
+      gridTemplateRows={!noFooter ? '1fr' : '1fr auto'}
     >
       {children}
       {!noFooter && <Footer />}
@@ -140,7 +139,7 @@ export default () => (
           <AuthRoute
             path="complete"
             element={
-              <RouteWrapper blackHeader noFooter>
+              <RouteWrapper noHeader noFooter>
                 <CoursePage which="projectComplete" />
               </RouteWrapper>
             }
@@ -176,7 +175,7 @@ export default () => (
           <AuthRoute
             path="complete"
             element={
-              <RouteWrapper blackHeader inConcept noFooter>
+              <RouteWrapper noHeader noFooter>
                 <CoursePage which="lessonComplete" />
               </RouteWrapper>
             }
@@ -184,7 +183,7 @@ export default () => (
           <AuthRoute
             path=":concept"
             element={
-              <RouteWrapper noHeader inConcept noFooter>
+              <RouteWrapper noHeader noFooter>
                 <CoursePage which="concept" />
               </RouteWrapper>
             }


### PR DESCRIPTION
## Description
This adds a wrapper to all routes that allows setting, for each route, their main header and their main footer. You can also set if the header bg is black and a variable to define the gridTemplate in concept pages.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
