### PR TITLE
Popup trigger event should stop propagation

### DIFF
--- a/apps/courses/src/components/Popover.tsx
+++ b/apps/courses/src/components/Popover.tsx
@@ -65,7 +65,9 @@ export const Popover = ({
       }
     >
       <Box
-        onClick={() => {
+        onClick={(ev) => {
+          // stopPropagation, or it will invoke onClickOutside, thus closes the popup right away
+          ev.stopPropagation();
           if (onOpen) onOpen(!show);
           else setShow(!show);
         }}


### PR DESCRIPTION
## Description
react-tiny-popup trigger event fires the onCloseOutsite right away, Trigger event should not be propagated.

## Affected Dependencies
None

## How has this been tested?
None

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
