### PR TITLE
Fix for issue #92: course filter selection states

### DIFF
--- a/apps/courses/src/routes/courses/search/Sidebar.tsx
+++ b/apps/courses/src/routes/courses/search/Sidebar.tsx
@@ -50,7 +50,7 @@ const SidebarItem = ({
         <RadioGroup colorScheme="blue" value={value} onChange={(val) => setter(val)}>
           <Stack>
             {options.map((item) => (
-              <Radio value={item} key={item}>
+              <Radio value={item} key={item} isChecked={item === value}>
                 {item}
               </Radio>
             ))}


### PR DESCRIPTION
## Description
Addresses bug ticket https://github.com/OpenMined/openmined/issues/92 by fixing the following errors on the `/courses` page:
* allowing multiple course filters to be selected
* "Clear filters" button not resetting filters state

## Affected Dependencies
None

## How has this been tested?
Manual testing in dev environment

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
