### PR TITLE
Fixes feedback not loading for students

### DIFF
--- a/apps/courses/src/routes/courses/project-submission/index.tsx
+++ b/apps/courses/src/routes/courses/project-submission/index.tsx
@@ -4,7 +4,7 @@ import {
   CoursePagesProp,
   CourseProjectSubmission,
 } from '@openmined/shared/types';
-import { useFirestoreDocDataOnce } from 'reactfire';
+import { useFirestoreDocData } from 'reactfire';
 
 import Student from './Student';
 import Mentor from './Mentor';
@@ -40,7 +40,7 @@ export default (props: CoursePagesProp) => {
     ? content.submissions[+attempt - 1].submission
     : null;
   const attemptData: CourseProjectSubmission = attemptRef
-    ? useFirestoreDocDataOnce(attemptRef)
+    ? useFirestoreDocData(attemptRef)
     : null;
 
   return (


### PR DESCRIPTION
## Description
Some submissions were reviewed but the feedback might not appear for the student. The reason is that we were not subscribing to document changes by using `useFirestoreDocDataOnce`, which maintains the data the same during various scenarios. We now subscribe to document changes by using `useFirestoreDocData`.

## How has this been tested?
- Log in as a student
- Make a project submission
- Log out
- Log in as a mentor
- Start the review process for the project submission
- Reject the submission with some feedback and log out
- Log in as the same student, visit the submission page
- Feedback should now be visible

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests

Tests are welcome!