### PR TITLE
Fix for issue #88: mentor dashboard tab overlap

### DIFF
--- a/apps/courses/src/components/ColoredTabs.tsx
+++ b/apps/courses/src/components/ColoredTabs.tsx
@@ -16,6 +16,7 @@ const tabProps = {
     borderColor: 'blue.100',
     borderBottom: '2px solid',
     borderBottomColor: ['blue.100', null, 'blue.700'],
+    zIndex: 0,
   },
 };
 


### PR DESCRIPTION
## Description
Resolves https://github.com/OpenMined/openmined/issues/88
Ensures the z-index of a selected tab in the mentor dashboard does not overlap the header.

## Affected Dependencies
None

## How has this been tested?
Manually tested locally

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests

### Bug behavior:
![mentor_dashboard_tabs](https://user-images.githubusercontent.com/4998605/106825576-03092780-663a-11eb-8006-6a30ef70c564.gif)
