### PR TITLE
Fix: Restrict homepage courses list to published versions 

### DIFF
--- a/apps/firebase-api/src/app/sanity/utils/queries.ts
+++ b/apps/firebase-api/src/app/sanity/utils/queries.ts
@@ -144,7 +144,7 @@ export const concept = ({ lesson, concept, isAdmin }) => `
 }[0]`;
 
 export const homepageCourses = () => `
-*[_type == "course" && visible == true] {
+*[_type == "course" && visible == true && !(_id in path('drafts.**'))] {
   title,
   level,
   length,


### PR DESCRIPTION
Blocks courses in draft state from appearing as a duplicate in the list of courses.