### PR TITLE
feat: adds Simulcast support to courses 1.0

### DIFF
--- a/apps/courses/src/components/CourseCard.tsx
+++ b/apps/courses/src/components/CourseCard.tsx
@@ -1,11 +1,19 @@
 import React from 'react';
-import { Box, Text, Flex, Image, Heading, ChakraProps } from '@chakra-ui/react';
+import {
+  Box,
+  Text,
+  Flex,
+  Image,
+  Heading,
+  ChakraProps,
+  Badge,
+} from '@chakra-ui/react';
 import { Link } from 'react-router-dom';
 
 import theme from '../theme';
 
 export default ({ content, ...props }) => {
-  const { title, visual, cost, level, length, slug, live } = content;
+  const { title, visual, cost, level, length, slug, live, simulcast } = content;
 
   const absoluteOpacityStyles: ChakraProps = {
     position: 'absolute',
@@ -46,9 +54,18 @@ export default ({ content, ...props }) => {
       />
       <Flex p={6} direction="column" justifyContent="space-between" flex={1}>
         <Box>
-          <Text fontFamily="mono" color="gray.400" textAlign="right" mb={2}>
-            {cost.toUpperCase()}
-          </Text>
+          <Flex justifyContent="space-between" alignItems="center" mb={2}>
+            <span>
+              {simulcast && (
+                <Badge color="white" bgColor="blue.700">
+                  Simulcast
+                </Badge>
+              )}
+            </span>
+            <Text fontFamily="mono" color="gray.400" textAlign="right">
+              {cost.toUpperCase()}
+            </Text>
+          </Flex>
           <Heading as="h3" size="lg" mb={8}>
             {title}
           </Heading>

--- a/apps/courses/src/components/CourseProgressCard.tsx
+++ b/apps/courses/src/components/CourseProgressCard.tsx
@@ -1,5 +1,13 @@
 import React from 'react';
-import { Box, Text, Flex, Heading, Progress, Divider } from '@chakra-ui/react';
+import {
+  Badge,
+  Box,
+  Text,
+  Flex,
+  Heading,
+  Progress,
+  Divider,
+} from '@chakra-ui/react';
 import { Link } from 'react-router-dom';
 import {
   faArrowRight,
@@ -12,9 +20,20 @@ import {
   hasCompletedLesson,
 } from '../routes/courses/_helpers';
 import Icon from '../components/Icon';
+import dayjs from 'dayjs';
 
 export default ({ content, ...props }) => {
-  const { title, slug, level, length, lessons, project, progress } = content;
+  const {
+    title,
+    slug,
+    level,
+    length,
+    lessons,
+    project,
+    progress,
+    simulcast,
+    simulcast_release_date,
+  } = content;
 
   const stats = getCourseProgress(progress, lessons, project?.parts);
   const percentComplete =
@@ -27,6 +46,10 @@ export default ({ content, ...props }) => {
 
   if (nextAvailablePage.concept) {
     resumeLink = `${resumeLink}/${nextAvailablePage.concept}`;
+  }
+
+  if (simulcast && percentComplete === 100) {
+    resumeLink = null;
   }
 
   return (
@@ -53,6 +76,9 @@ export default ({ content, ...props }) => {
         </Flex>
         <Box bg="blue.50" p={4} borderRadius="md" mb={4}>
           {lessons.map((l, i) => {
+            const shouldShowNextBadge =
+              i > 0 && lessons[i - 1].concepts?.length > 0 && !l.concepts;
+
             const iconProps = hasCompletedLesson(progress, l._id)
               ? {
                   icon: faCheckCircle,
@@ -63,28 +89,61 @@ export default ({ content, ...props }) => {
                 };
 
             return (
-              <Flex align="center" mt={i === 0 ? 0 : 2} key={i}>
-                <Icon {...iconProps} mr={3} boxSize={5} />
-                <Text color="gray.700">{l.title}</Text>
+              <Flex
+                align="center"
+                mt={i === 0 ? 0 : 2}
+                key={i}
+                justifyContent="space-between"
+              >
+                <Flex>
+                  <Icon {...iconProps} mr={3} boxSize={5} />
+                  <Text color="gray.700">{l.title}</Text>
+                </Flex>
+                {shouldShowNextBadge && (
+                  <Badge color="white" bgColor="blue.700" justifySelf="end">
+                    Next
+                  </Badge>
+                )}
               </Flex>
             );
           })}
           {project && (
-            <Flex align="center" mt={2}>
-              <Icon icon={faShapes} mr={3} color="gray.600" boxSize={5} />
-              <Text color="gray.700">{project.title}</Text>
+            <Flex align="center" mt={2} justifyContent="space-between">
+              <Flex>
+                <Icon icon={faShapes} mr={3} color="gray.600" boxSize={5} />
+                <Text color="gray.700">{project.title}</Text>
+              </Flex>
+              {simulcast &&
+                !project.parts &&
+                lessons[lessons.length - 1].concepts?.length > 0 && (
+                  <Badge color="white" bgColor="blue.700" justifySelf="end">
+                    Next
+                  </Badge>
+                )}
             </Flex>
           )}
         </Box>
         <Flex justify="flex-end">
-          <Link to={resumeLink}>
-            <Flex align="center">
+          {resumeLink && (
+            <Link to={resumeLink}>
+              <Flex align="center">
+                <Text fontWeight="bold" mr={3}>
+                  Resume
+                </Text>
+                <Icon icon={faArrowRight} />
+              </Flex>
+            </Link>
+          )}
+          {!resumeLink && (
+            <Flex align="center" color="GrayText">
               <Text fontWeight="bold" mr={3}>
-                Resume
+                Coming{' '}
+                {simulcast_release_date
+                  ? dayjs(simulcast_release_date).fromNow()
+                  : 'soon'}
               </Text>
-              <Icon icon={faArrowRight} />
             </Flex>
-          </Link>
+          )}
         </Flex>
       </Box>
       <Progress colorScheme="blue" value={percentComplete} />

--- a/apps/courses/src/components/NumberedAccordion.tsx
+++ b/apps/courses/src/components/NumberedAccordion.tsx
@@ -5,13 +5,16 @@ import {
   AccordionIcon,
   AccordionItem,
   AccordionPanel,
+  Badge,
   Circle,
   Flex,
   Heading,
   Image,
+  Text,
 } from '@chakra-ui/react';
 
 import Icon from './Icon';
+import dayjs from 'dayjs';
 
 export const CircledNumber = ({ isActive = false, children, ...props }) => {
   const circleProps = isActive
@@ -44,38 +47,58 @@ export const CircledNumber = ({ isActive = false, children, ...props }) => {
   );
 };
 
-export default ({ indexes, onToggleItem, sections, ...props }) => (
+export default ({
+  indexes,
+  onToggleItem,
+  sections,
+  simulcastReleaseDate,
+  ...props
+}) => (
   <Accordion index={indexes} allowMultiple {...props}>
-    {sections.map(({ title, content, image, icon, ...section }, index) => (
-      <AccordionItem
-        border="0px"
-        mt={index === 0 ? 0 : 8}
-        key={index}
-        {...section}
-      >
-        <Flex alignItems="center" onClick={() => onToggleItem(index)}>
-          {!icon && !image && (
-            <CircledNumber mr={6} size={10} isActive={indexes.includes(index)}>
-              {index + 1}
-            </CircledNumber>
-          )}
-          {icon && <Icon icon={icon} boxSize={10} mr={6} />}
-          {image && <Image src={image} alt={title} boxSize={10} mr={6} />}
-          <AccordionButton
-            px={0}
-            borderBottomWidth="1px"
-            _hover={{ backgroundColor: 'initial' }}
-          >
-            <Heading size="lg" as="h3" flex="1" textAlign="left">
-              {title}
-            </Heading>
-            <AccordionIcon fontSize="1.5rem" />
-          </AccordionButton>
-        </Flex>
-        <AccordionPanel ml={4} pl={12} pr={0} pt={4}>
-          {content}
-        </AccordionPanel>
-      </AccordionItem>
-    ))}
+    {sections.map(({ title, content, image, icon, ...section }, index) => {
+      const shouldShowComingSoonBadge =
+        index > 0 &&
+        (sections[index - 1].concepts?.length > 0 || sections[index - 1].parts);
+      return (
+        <AccordionItem
+          border="0px"
+          mt={index === 0 ? 0 : 8}
+          key={index}
+          {...section}
+        >
+          <Flex alignItems="center" onClick={() => onToggleItem(index)}>
+            {!icon && !image && (
+              <CircledNumber
+                mr={6}
+                size={10}
+                isActive={indexes.includes(index)}
+              >
+                {index + 1}
+              </CircledNumber>
+            )}
+            {icon && <Icon icon={icon} boxSize={10} mr={6} />}
+            {image && <Image src={image} alt={title} boxSize={10} mr={6} />}
+            <AccordionButton
+              px={0}
+              borderBottomWidth="1px"
+              _hover={{ backgroundColor: 'initial' }}
+            >
+              <Heading size="lg" as="h3" flex="1" textAlign="left">
+                {title}
+              </Heading>
+              {shouldShowComingSoonBadge && (
+                <Badge color="white" bgColor="blue.700" mr={4}>
+                  Coming {dayjs(simulcastReleaseDate).fromNow()}
+                </Badge>
+              )}
+              <AccordionIcon fontSize="1.5rem" />
+            </AccordionButton>
+          </Flex>
+          <AccordionPanel ml={4} pl={12} pr={0} pt={4}>
+            {content}
+          </AccordionPanel>
+        </AccordionItem>
+      );
+    })}
   </Accordion>
 );

--- a/apps/courses/src/routes/courses/_helpers.ts
+++ b/apps/courses/src/routes/courses/_helpers.ts
@@ -34,7 +34,7 @@ export const getCourseProgress = (u, ls, ps): CourseProgress => {
 
     if (hasCompletedLesson(u, l._id)) numCompletedLessons++;
 
-    l.concepts.forEach((c) => {
+    l.concepts?.forEach((c) => {
       numConcepts++;
 
       if (hasCompletedConcept(u, l._id, c._id)) numCompletedConcepts++;

--- a/apps/courses/src/routes/courses/_helpers.ts
+++ b/apps/courses/src/routes/courses/_helpers.ts
@@ -212,9 +212,9 @@ export const getNextAvailablePage = (u, ls): NextAvailablePage => {
   // If we haven't started the course at all, send them to the first lesson initiation page
   if (!hasStartedCourse(u)) return { lesson: ls[0]._id, concept: null };
 
-  for (let i = 0; i < ls.length; i++) {
+  for (let i = 0; i < ls.length && ls[i].concepts?.length > 0; i++) {
     const currentLesson = ls[i];
-
+    console.log({ ls, currentLesson, i, l: ls[i] });
     // If lesson is not started, make sure to mark with started_at
     if (!hasStartedLesson(u, currentLesson._id)) {
       return { lesson: currentLesson._id, concept: null };

--- a/apps/courses/src/routes/courses/lesson-complete/index.tsx
+++ b/apps/courses/src/routes/courses/lesson-complete/index.tsx
@@ -10,6 +10,8 @@ import {
   Link,
   Text,
   Textarea,
+  Image,
+  Badge,
 } from '@chakra-ui/react';
 import {
   faArrowRight,
@@ -29,6 +31,7 @@ import Icon from '../../../components/Icon';
 import { handleErrors } from '../../../helpers';
 import { useNavigate } from 'react-router-dom';
 import { discussionLink } from '../../../content/links';
+import dayjs from 'dayjs';
 
 const DetailLink = ({ icon, children, ...props }) => (
   <Box
@@ -42,7 +45,7 @@ const DetailLink = ({ icon, children, ...props }) => (
   </Box>
 );
 
-const LessonLine = ({ status, title, type }) => {
+const LessonLine = ({ status, title, type, simulcastReleaseDate = '' }) => {
   let color, icon, iconColor;
 
   if (status === 'current') {
@@ -62,6 +65,10 @@ const LessonLine = ({ status, title, type }) => {
     } else if (type === 'project') {
       icon = faShapes;
     }
+  } else if (status === 'simulcast') {
+    color = 'white';
+    icon = faArrowRight;
+    iconColor = 'cyan.500';
   }
 
   return (
@@ -85,6 +92,11 @@ const LessonLine = ({ status, title, type }) => {
           Up Next
         </Text>
       )}
+      {status === 'simulcast' && (
+        <Badge color="white" bgColor="blue.700">
+          Coming {dayjs(simulcastReleaseDate).fromNow() ?? 'soon'}
+        </Badge>
+      )}
     </Flex>
   );
 };
@@ -101,7 +113,7 @@ export default ({
   const navigate = useNavigate();
 
   const {
-    course: { lessons, projectTitle },
+    course: { lessons, projectTitle, simulcast_release_date },
     title,
   } = page;
 
@@ -116,8 +128,15 @@ export default ({
   // Get the current lesson index, the lesson number, and (if applicable) the next lesson or final project
   const lessonIndex = getLessonIndex(lessons, lesson);
   const lessonNum = lessonIndex + 1;
-  const nextLesson =
-    lessons.length > lessonNum ? lessons[lessonNum] : 'project';
+  let nextLesson;
+
+  if (lessons.length > lessonNum) {
+    nextLesson = lessons[lessonNum];
+  } else if (projectTitle) {
+    nextLesson = 'project';
+  } else {
+    nextLesson = null;
+  }
 
   // Create a function that is triggered when the lesson is completed
   // This is triggered by clicking the "Next" button in the <ConceptFooter />
@@ -154,9 +173,18 @@ export default ({
       <GridContainer py={[8, null, null, 16]}>
         {!isFeedbackActive && (
           <Flex direction="column" align="center" maxW={600} mx="auto">
-            <Icon icon={faCheckCircle} color="cyan.300" boxSize={12} mb={4} />
+            {nextLesson ? (
+              <Icon icon={faCheckCircle} color="cyan.300" boxSize={12} mb={4} />
+            ) : (
+              <Image
+                src="https://emojis.slackmojis.com/emojis/images/1572027878/6937/blob_thumbs_up.png?1572027878"
+                alt="Yes"
+                boxSize={12}
+                mb={3}
+              />
+            )}
             <Heading as="p" size="xl" textAlign="center" mb={4}>
-              Congratulations!
+              {nextLesson ? 'Congratulations!' : 'Keep up the good work!'}
             </Heading>
             <Heading
               as="p"
@@ -176,24 +204,35 @@ export default ({
               <Text
                 color="gray.400"
                 fontStyle="italic"
-                width={200}
                 textAlign="center"
+                mx={4}
+                flexShrink={0}
               >
-                Up Next
+                {nextLesson ? 'Up Next' : 'Continue learning'}
               </Text>
               <Divider />
             </Flex>
             <Box borderRadius="md" overflow="hidden" width="full" mb={8}>
-              <LessonLine status="current" type="lessson" title={title} />
+              <LessonLine status="current" type="lesson" title={title} />
               {lessons.length > lessonIndex + 1 && (
                 <LessonLine
-                  status="next"
+                  status={
+                    lessons[lessonIndex + 1].concepts?.length
+                      ? 'next'
+                      : 'simulcast'
+                  }
                   type="lesson"
                   title={lessons[lessonIndex + 1].title}
+                  simulcastReleaseDate={simulcast_release_date}
                 />
               )}
               {lessons.length === lessonIndex + 1 && (
-                <LessonLine status="next" type="project" title={projectTitle} />
+                <LessonLine
+                  status={projectTitle ? 'next' : 'simulcast'}
+                  type="project"
+                  title={projectTitle ?? 'New content'}
+                  simulcastReleaseDate={simulcast_release_date}
+                />
               )}
               {lessons.length > lessonIndex + 2 && (
                 <LessonLine
@@ -202,7 +241,7 @@ export default ({
                   title={lessons[lessonIndex + 2].title}
                 />
               )}
-              {lessons.length === lessonIndex + 2 && (
+              {lessons.length === lessonIndex + 2 && projectTitle && (
                 <LessonLine
                   status="later"
                   type="project"
@@ -210,28 +249,61 @@ export default ({
                 />
               )}
             </Box>
-            <Button
-              mb={12}
-              colorScheme="cyan"
-              size="lg"
-              onClick={() =>
-                onCompleteLesson().then(() => {
-                  // TODO: https://github.com/OpenMined/openmined/issues/53
-                  // navigate(
-                  //   `/courses/${course}/${
-                  //     typeof nextLesson === 'string'
-                  //       ? nextLesson
-                  //       : nextLesson._id
-                  //   }`
-                  // );
-                  window.location.href = `/courses/${course}/${
-                    typeof nextLesson === 'string' ? nextLesson : nextLesson._id
-                  }`;
-                })
-              }
-            >
-              Continue
-            </Button>
+            {nextLesson && lessons[lessonIndex + 1].concepts?.length > 0 ? (
+              <Button
+                mb={12}
+                colorScheme="cyan"
+                size="lg"
+                onClick={() =>
+                  onCompleteLesson().then(() => {
+                    // TODO: https://github.com/OpenMined/openmined/issues/53
+                    // navigate(
+                    //   `/courses/${course}/${
+                    //     typeof nextLesson === 'string'
+                    //       ? nextLesson
+                    //       : nextLesson._id
+                    //   }`
+                    // );
+                    if (nextLesson) {
+                      window.location.href = `/courses/${course}/${
+                        typeof nextLesson === 'string'
+                          ? nextLesson
+                          : nextLesson._id
+                      }`;
+                    } else {
+                      window.location.href = `/courses/${course}`;
+                    }
+                  })
+                }
+              >
+                Continue
+              </Button>
+            ) : (
+              <>
+                <Text
+                  my={8}
+                  align="center"
+                  color="gray.400"
+                  display={['block', 'none']}
+                >
+                  You will be notified via email when the next lesson is
+                  released. Until then check out some of our other learning
+                  resources below
+                </Text>
+                <Text
+                  my={8}
+                  align="center"
+                  color="gray.400"
+                  display={['none', 'block']}
+                >
+                  You will be notified via email when the next lesson is
+                  released.
+                  <br />
+                  Until then check out some of our other learning resources
+                  below
+                </Text>
+              </>
+            )}
             <Flex
               direction={{ base: 'column', md: 'row' }}
               justify="space-between"
@@ -313,7 +385,6 @@ export default ({
                 onClick={() => {
                   onProvideFeedback(vote, feedback).then(() => {
                     setFeedbackActive(false);
-
                     toast({
                       ...toastConfig,
                       title: 'Feedback sent',

--- a/apps/courses/src/routes/courses/lesson-complete/index.tsx
+++ b/apps/courses/src/routes/courses/lesson-complete/index.tsx
@@ -113,7 +113,7 @@ export default ({
   const navigate = useNavigate();
 
   const {
-    course: { lessons, projectTitle, simulcast_release_date },
+    course: { lessons, projectTitle, simulcast, simulcast_release_date },
     title,
   } = page;
 
@@ -168,23 +168,26 @@ export default ({
     { text: '👍', val: 1 },
   ];
 
+  const simulcastEnd =
+    simulcast && lessons[lessonIndex + 1]?.concepts === undefined;
+
   return (
     <Box bg="gray.900" color="white">
       <GridContainer py={[8, null, null, 16]}>
         {!isFeedbackActive && (
           <Flex direction="column" align="center" maxW={600} mx="auto">
-            {nextLesson ? (
-              <Icon icon={faCheckCircle} color="cyan.300" boxSize={12} mb={4} />
-            ) : (
+            {simulcastEnd ? (
               <Image
                 src="https://emojis.slackmojis.com/emojis/images/1572027878/6937/blob_thumbs_up.png?1572027878"
                 alt="Yes"
                 boxSize={12}
                 mb={3}
               />
+            ) : (
+              <Icon icon={faCheckCircle} color="cyan.300" boxSize={12} mb={4} />
             )}
             <Heading as="p" size="xl" textAlign="center" mb={4}>
-              {nextLesson ? 'Congratulations!' : 'Keep up the good work!'}
+              {simulcastEnd ? 'Keep up the good work!' : 'Congratulations!'}
             </Heading>
             <Heading
               as="p"
@@ -208,7 +211,7 @@ export default ({
                 mx={4}
                 flexShrink={0}
               >
-                {nextLesson ? 'Up Next' : 'Continue learning'}
+                {simulcastEnd ? 'Continue learning' : 'Up Next'}
               </Text>
               <Divider />
             </Flex>
@@ -249,7 +252,32 @@ export default ({
                 />
               )}
             </Box>
-            {nextLesson && lessons[lessonIndex + 1].concepts?.length > 0 ? (
+            {simulcastEnd ? (
+              <>
+                <Text
+                  mb={12}
+                  align="center"
+                  color="gray.400"
+                  display={['block', 'none']}
+                >
+                  You will be notified via email when the next lesson is
+                  released. Until then check out some of our other learning
+                  resources below
+                </Text>
+                <Text
+                  mb={12}
+                  align="center"
+                  color="gray.400"
+                  display={['none', 'block']}
+                >
+                  You will be notified via email when the next lesson is
+                  released.
+                  <br />
+                  Until then check out some of our other learning resources
+                  below
+                </Text>
+              </>
+            ) : (
               <Button
                 mb={12}
                 colorScheme="cyan"
@@ -264,45 +292,16 @@ export default ({
                     //       : nextLesson._id
                     //   }`
                     // );
-                    if (nextLesson) {
-                      window.location.href = `/courses/${course}/${
-                        typeof nextLesson === 'string'
-                          ? nextLesson
-                          : nextLesson._id
-                      }`;
-                    } else {
-                      window.location.href = `/courses/${course}`;
-                    }
+                    window.location.href = `/courses/${course}/${
+                      typeof nextLesson === 'string'
+                        ? nextLesson
+                        : nextLesson._id
+                    }`;
                   })
                 }
               >
                 Continue
               </Button>
-            ) : (
-              <>
-                <Text
-                  my={8}
-                  align="center"
-                  color="gray.400"
-                  display={['block', 'none']}
-                >
-                  You will be notified via email when the next lesson is
-                  released. Until then check out some of our other learning
-                  resources below
-                </Text>
-                <Text
-                  my={8}
-                  align="center"
-                  color="gray.400"
-                  display={['none', 'block']}
-                >
-                  You will be notified via email when the next lesson is
-                  released.
-                  <br />
-                  Until then check out some of our other learning resources
-                  below
-                </Text>
-              </>
             )}
             <Flex
               direction={{ base: 'column', md: 'row' }}

--- a/apps/courses/src/routes/courses/overview/index.tsx
+++ b/apps/courses/src/routes/courses/overview/index.tsx
@@ -52,6 +52,7 @@ import hexagon from '../../../assets/hexagon.svg';
 import heptagon from '../../../assets/heptagon.svg';
 import waveform from '../../../assets/waveform/waveform-top-left-cool.png';
 import currentLessonIcon from '../../../assets/homepage/finger-point.svg';
+import dayjs from 'dayjs';
 
 const Detail = ({ title, value, icon = faCheckCircle }) => (
   <Flex align="center" mb={4}>
@@ -115,63 +116,65 @@ export default ({ course, page, progress }: CoursePagesProp) => {
     isTakingCourse
   ) => (
     <Box bg="gray.200" p={8}>
-      <Text mb={4}>
+      <Text>
         {typeof description === 'string' ? description : description()}
       </Text>
-      <List spacing={2}>
-        {parts.map(({ title, _id, type, _key }, index) => {
-          let isComplete = false;
+      {parts && (
+        <List spacing={2} mt={4}>
+          {parts.map(({ title, _id, type, _key }, index) => {
+            let isComplete = false;
 
-          if (progress) {
-            isComplete =
-              _id && !_key
-                ? hasCompletedConcept(progress, lessonId, _id)
-                : hasCompletedProjectPart(progress, _key);
-          }
+            if (progress) {
+              isComplete =
+                _id && !_key
+                  ? hasCompletedConcept(progress, lessonId, _id)
+                  : hasCompletedProjectPart(progress, _key);
+            }
 
-          let icon;
+            let icon;
 
-          const conceptIcon = type
-            ? type === 'video'
-              ? faPlayCircle
-              : faFile
-            : null;
+            const conceptIcon = type
+              ? type === 'video'
+                ? faPlayCircle
+                : faFile
+              : null;
 
-          if (isComplete) {
-            if (conceptIcon) icon = conceptIcon;
-            else icon = faCheckCircle;
-          } else {
-            if (conceptIcon) icon = conceptIcon;
-            else icon = faCircle;
-          }
+            if (isComplete) {
+              if (conceptIcon) icon = conceptIcon;
+              else icon = faCheckCircle;
+            } else {
+              if (conceptIcon) icon = conceptIcon;
+              else icon = faCircle;
+            }
 
-          const iconProps: any = {
-            boxSize: 5,
-            mr: 2,
-            color: isComplete ? 'blue.500' : 'gray.600',
-          };
+            const iconProps: any = {
+              boxSize: 5,
+              mr: 2,
+              color: isComplete ? 'blue.500' : 'gray.600',
+            };
 
-          return (
-            <ListItem key={index} display="flex" alignItems="center">
-              <ListIcon as={() => <Icon {...iconProps} icon={icon} />} />
-              {isComplete && (
-                <a
-                  href={
-                    lessonId
-                      ? `/courses/${course}/${lessonId}/${_id}`
-                      : `/courses/${course}/project/${_key}`
-                  }
-                  target="_self"
-                >
-                  {title}
-                </a>
-              )}
-              {!isComplete && title}
-            </ListItem>
-          );
-        })}
-      </List>
-      {isCurrent && isTakingCourse && (
+            return (
+              <ListItem key={index} display="flex" alignItems="center">
+                <ListIcon as={() => <Icon {...iconProps} icon={icon} />} />
+                {isComplete && (
+                  <a
+                    href={
+                      lessonId
+                        ? `/courses/${course}/${lessonId}/${_id}`
+                        : `/courses/${course}/project/${_key}`
+                    }
+                    target="_self"
+                  >
+                    {title}
+                  </a>
+                )}
+                {!isComplete && title}
+              </ListItem>
+            );
+          })}
+        </List>
+      )}
+      {isCurrent && isTakingCourse && parts && (
         <Flex justify="flex-end" mt={4}>
           {/* TODO: https://github.com/OpenMined/openmined/issues/53 */}
           {/* <Link to={resumeLink}> */}
@@ -199,6 +202,8 @@ export default ({ course, page, progress }: CoursePagesProp) => {
     certification,
     learnFrom,
     live,
+    simulcast,
+    simulcast_release_date,
     project,
   } = page;
 
@@ -227,6 +232,10 @@ export default ({ course, page, progress }: CoursePagesProp) => {
     resumeLink = `${resumeLink}/${nextAvailablePage.concept}`;
   }
 
+  if (simulcast && percentComplete === 100) {
+    resumeLink = null;
+  }
+
   const determineOpenLessons = () => {
     if (!isTakingCourse) return [0];
     if (hasCompletedCourse(progress)) return [];
@@ -253,6 +262,7 @@ export default ({ course, page, progress }: CoursePagesProp) => {
   const lessons = page.lessons
     ? page.lessons.map(({ title, description, concepts, _id }, index) => ({
         title,
+        concepts,
         content: prepareSyllabusContent(
           description,
           concepts,
@@ -270,6 +280,7 @@ export default ({ course, page, progress }: CoursePagesProp) => {
   if (project) {
     lessons.push({
       title: project.title,
+      parts: project.parts,
       content: prepareSyllabusContent(
         project.description,
         project.parts,
@@ -381,10 +392,17 @@ export default ({ course, page, progress }: CoursePagesProp) => {
                     // to={resumeLink}
                     as="a"
                     href={resumeLink}
+                    disabled={!resumeLink}
                     target="_self"
                     ml={4}
                   >
-                    Continue
+                    {resumeLink
+                      ? 'Continue'
+                      : `Coming ${
+                          simulcast_release_date
+                            ? dayjs(simulcast_release_date).fromNow()
+                            : 'soon'
+                        }`}
                   </Button>
                 </Flex>
               )}
@@ -430,6 +448,7 @@ export default ({ course, page, progress }: CoursePagesProp) => {
                 indexes={indexes}
                 onToggleItem={toggleAccordionItem}
                 sections={lessons}
+                simulcastReleaseDate={simulcast_release_date}
               />
             )}
             {lessons.length === 0 && (
@@ -467,7 +486,7 @@ export default ({ course, page, progress }: CoursePagesProp) => {
               {courseStartLink ? 'Start Course' : 'Coming Soon'}
             </Button>
           )}
-          {isTakingCourse && (
+          {isTakingCourse && resumeLink && (
             <Button
               colorScheme="black"
               size="lg"

--- a/apps/firebase-api/src/app/sanity/utils/queries.ts
+++ b/apps/firebase-api/src/app/sanity/utils/queries.ts
@@ -4,13 +4,15 @@ export type SANITY_QUERY = {
 };
 
 export const search = () => `
-*[_type == "course" && visible == true] {
+*[_type == "course" && visible == true && !(_id in path('drafts.**'))] {
   title,
   description,
   level,
   length,
   cost,
   live,
+  simulcast,
+  simulcast_release_date,
   "slug": slug.current,
   visual {
     "default": default.asset -> url,
@@ -109,6 +111,8 @@ export const lessonComplete = ({ lesson, isAdmin }) => `
   description,
   resources,
   "course": *[_type == "course" && references(^._id)][0] {
+    simulcast,
+    simulcast_release_date,
     title,
     "projectTitle": project.title,
     "lessons": lessons[] -> {
@@ -150,6 +154,8 @@ export const homepageCourses = () => `
   length,
   cost,
   live,
+  simulcast,
+  simulcast_release_date,
   "slug": slug.current,
   visual {
     "default": default.asset -> url,

--- a/apps/sanity-api/src/schemas/course.ts
+++ b/apps/sanity-api/src/schemas/course.ts
@@ -23,6 +23,19 @@ export default {
       type: 'boolean',
     },
     {
+      title: 'Is simulcast?',
+      description:
+        'Is there any content to be added to this course in a posterior date?',
+      name: 'simulcast',
+      type: 'boolean',
+    },
+    {
+      title: 'Next lesson/project date',
+      description: 'Next lesson/project release date',
+      name: 'simulcast_release_date',
+      type: 'datetime',
+    },
+    {
       title: 'Title',
       name: 'title',
       type: 'string',


### PR DESCRIPTION
Adds Simulcast support to courses-1.0

Here is the first support for "Simulcast" courses to the app. Simulcast
are courses that are released in several chunks of lessons, being
finalized with one or more projects. The main point of this patch is to
support Simulcast for the next batch of courses. We still need to access
Simulcast courses in the 2.0 version.

We didn't do much planning to get this to work; and tests were a bit
limited to scenarios such as:
- no further lessons nor projects added
- lessons without concepts but no projects
- lessons without concepts and projects without parts
- no further lessons but with projects without parts

This patch introduces the following changes to the front end:
- homepage: added "Simulcast" tag to course card
- search: added "Simulcast" tag to course search
- course overview: added "Coming in X days" badge to lessons
      accordion, blocked "Resume ->" text and link from appearing to
      courses without concepts and projects without parts. Buttons for
      incomplete courses are set to `disabled` and their text now reads
      "Coming in X days" for Simulcasts where the user cannot continue
- dashboard: added a "Next" badge and a "Coming in X days" message
      to the progress card
- lesson completed: changed the copy when users hit the end of the
      Simulcast and added a new image; removed the continue button

Sanity got updated to support Simulcast by adding two fields --
a `simulcast` boolean and a `simulcast_release_date` datetime -- that
indicates if a course is a simulcast and when the next patch of content
is expected to be added. At this time, the courses are very dependent on
these variables to work properly.

Courses:
- `components/CourseCard.tsx`: added Simulcast badge
- `components/CourseProgressCard.tsx`: added "Next" badge next to
    lessons and projects and a disabled button to block users from continuing
    these courses with "Coming in X days/Coming soon" copy
- `components/NumberedAccordion.tsx`: added the "Coming in X days/Coming
    soon" badge to accordion title `routes/courses/_helpers.tsx`: added
    some safe guarding for lessons without concepts
- `routes/courses/lesson-complete`: changed the copy to reflect the end of
    Simulcast lessons when the next lesson or project is to be released
    in a later date
- `routes/courses/overview`: updated `prepareSyllabusContent` to handle
    lessons and projects without concepts and parts and the cases when
    the student has actually finished all the available courses. Also
    serves as the entry point for the simulcast and
    simulcast_release_date

Sanity:
- `app/sanity/utils/queries.ts`: removes draft courses and adds the new
    variables to sanity responses
- `schema/courses.ts`: sets the new simulcast and simulcast_release_date
    courses fields

As stated, tests were limited.

