### PR TITLE
Ensure Mentors completion displays 100% in the Dashboard

### DIFF
--- a/apps/courses/src/components/CourseProgressCard.tsx
+++ b/apps/courses/src/components/CourseProgressCard.tsx
@@ -22,7 +22,7 @@ import {
 import Icon from '../components/Icon';
 import dayjs from 'dayjs';
 
-export default ({ content, ...props }) => {
+export default ({ content, isMentor, ...props }) => {
   const {
     title,
     slug,
@@ -36,18 +36,19 @@ export default ({ content, ...props }) => {
   } = content;
 
   const stats = getCourseProgress(progress, lessons, project?.parts);
-  let mentorState = props.ms;
+
   let percentComplete =
     ((stats.completedConcepts + stats.completedProjectParts) /
       (stats.concepts + stats.projectParts)) *
     100;
 
   // don't require project completion values for mentors
-  if (mentorState) {
+  if (isMentor) {
     percentComplete = (stats.completedConcepts / stats.concepts) * 100;
   }
 
   const nextAvailablePage = getNextAvailablePage(progress, lessons);
+
   let resumeLink = `/courses/${slug}/${nextAvailablePage.lesson}`;
 
   if (nextAvailablePage.concept) {

--- a/apps/courses/src/components/CourseProgressCard.tsx
+++ b/apps/courses/src/components/CourseProgressCard.tsx
@@ -36,10 +36,16 @@ export default ({ content, ...props }) => {
   } = content;
 
   const stats = getCourseProgress(progress, lessons, project?.parts);
-  const percentComplete =
+  let mentorState = props.ms;
+  let percentComplete =
     ((stats.completedConcepts + stats.completedProjectParts) /
       (stats.concepts + stats.projectParts)) *
     100;
+
+  // don't require project completion values for mentors
+  if (mentorState) {
+    percentComplete = (stats.completedConcepts / stats.concepts) * 100;
+  }
 
   const nextAvailablePage = getNextAvailablePage(progress, lessons);
   let resumeLink = `/courses/${slug}/${nextAvailablePage.lesson}`;

--- a/apps/courses/src/routes/courses/_helpers.ts
+++ b/apps/courses/src/routes/courses/_helpers.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { CoursePageWhich } from '@openmined/shared/types';
+import { CoursePageWhich, User } from '@openmined/shared/types';
+import { useFirestore } from 'reactfire';
 
 export interface CourseProgress {
   lessons?: number;
@@ -342,4 +343,26 @@ export const useCoursePermissionGate = (user, lessons, page, params) => {
   // Patrick, pick things up here...
 
   return { page, user, lessons, params };
+};
+
+export const userIsMentor = async (user: firebase.User) => {
+  const db = useFirestore();
+  const dbUserRef = db.collection('users').doc(user.uid);
+  const [dbUser, setDbUser] = useState<User>(null);
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      setDbUser((await dbUserRef.get()).data() as User);
+    };
+
+    if (user && user.uid && !dbUser) fetchUser();
+  }, [user, dbUser, dbUserRef]);
+
+  const isMentor =
+      dbUser &&
+      dbUser.is_mentor &&
+      dbUser.mentorable_courses &&
+      dbUser.mentorable_courses.length > 0;
+
+  return isMentor;
 };

--- a/apps/courses/src/routes/courses/_helpers.ts
+++ b/apps/courses/src/routes/courses/_helpers.ts
@@ -345,7 +345,13 @@ export const useCoursePermissionGate = (user, lessons, page, params) => {
   return { page, user, lessons, params };
 };
 
-export const userIsMentor = async (user: firebase.User) => {
+export const useIsMentor = ({
+  user,
+  course,
+}: {
+  user: firebase.User;
+  course: string;
+}): boolean => {
   const db = useFirestore();
   const dbUserRef = db.collection('users').doc(user.uid);
   const [dbUser, setDbUser] = useState<User>(null);
@@ -358,11 +364,5 @@ export const userIsMentor = async (user: firebase.User) => {
     if (user && user.uid && !dbUser) fetchUser();
   }, [user, dbUser, dbUserRef]);
 
-  const isMentor =
-      dbUser &&
-      dbUser.is_mentor &&
-      dbUser.mentorable_courses &&
-      dbUser.mentorable_courses.length > 0;
-
-  return isMentor;
+  return dbUser?.is_mentor && dbUser.mentorable_courses?.includes(course);
 };

--- a/apps/courses/src/routes/courses/overview/index.tsx
+++ b/apps/courses/src/routes/courses/overview/index.tsx
@@ -39,6 +39,7 @@ import {
   hasCompletedProject,
   hasCompletedProjectPart,
   hasStartedCourse,
+  userIsMentor,
 } from '../_helpers';
 import GridContainer from '../../../components/GridContainer';
 import NumberedAccordion from '../../../components/NumberedAccordion';
@@ -107,7 +108,7 @@ const LearnFrom = ({ image, name, credential }) => (
   </Flex>
 );
 
-export default ({ course, page, progress }: CoursePagesProp) => {
+export default ({ course, page, progress, user }: CoursePagesProp) => {
   const prepareSyllabusContent = (
     description,
     parts,
@@ -217,10 +218,18 @@ export default ({ course, page, progress }: CoursePagesProp) => {
   const stats = isTakingCourse
     ? getCourseProgress(progress, page.lessons, project?.parts)
     : {};
-  const percentComplete =
+
+  const isMentor = userIsMentor(user);
+
+  let percentComplete =
     ((stats.completedConcepts + stats.completedProjectParts) /
       (stats.concepts + stats.projectParts)) *
     100;
+
+  // don't require project completion values for mentors
+  if (isMentor) {
+    percentComplete = (stats.completedConcepts / stats.concepts) * 100;
+  }
 
   const nextAvailablePage = isTakingCourse
     ? getNextAvailablePage(progress, page.lessons)

--- a/apps/courses/src/routes/courses/overview/index.tsx
+++ b/apps/courses/src/routes/courses/overview/index.tsx
@@ -39,7 +39,7 @@ import {
   hasCompletedProject,
   hasCompletedProjectPart,
   hasStartedCourse,
-  userIsMentor,
+  useIsMentor,
 } from '../_helpers';
 import GridContainer from '../../../components/GridContainer';
 import NumberedAccordion from '../../../components/NumberedAccordion';
@@ -219,7 +219,7 @@ export default ({ course, page, progress, user }: CoursePagesProp) => {
     ? getCourseProgress(progress, page.lessons, project?.parts)
     : {};
 
-  const isMentor = userIsMentor(user);
+  const isMentor = useIsMentor({ user, course });
 
   let percentComplete =
     ((stats.completedConcepts + stats.completedProjectParts) /

--- a/apps/courses/src/routes/users/dashboard/Student.tsx
+++ b/apps/courses/src/routes/users/dashboard/Student.tsx
@@ -39,7 +39,7 @@ const combineProgressAndCourses = (courses, progress, filter) => {
   return tempCourses;
 };
 
-export const StudentContext = ({ courses, progress }) => {
+export const StudentContext = ({ courses, progress, userIsMentor }) => {
   const incompleteCourses = combineProgressAndCourses(
     courses,
     progress,
@@ -71,7 +71,7 @@ export const StudentContext = ({ courses, progress }) => {
   return (
     <SimpleGrid columns={1} spacing={4} width="full">
       {incompleteCourses.map((c) => (
-        <CourseProgressCard key={c.title} content={c} />
+        <CourseProgressCard key={c.title} content={c} ms={userIsMentor} />
       ))}
     </SimpleGrid>
   );

--- a/apps/courses/src/routes/users/dashboard/Student.tsx
+++ b/apps/courses/src/routes/users/dashboard/Student.tsx
@@ -71,7 +71,7 @@ export const StudentContext = ({ courses, progress, userIsMentor }) => {
   return (
     <SimpleGrid columns={1} spacing={4} width="full">
       {incompleteCourses.map((c) => (
-        <CourseProgressCard key={c.title} content={c} ms={userIsMentor} />
+        <CourseProgressCard key={c.title} content={c} isMentor={userIsMentor} />
       ))}
     </SimpleGrid>
   );

--- a/apps/courses/src/routes/users/dashboard/index.tsx
+++ b/apps/courses/src/routes/users/dashboard/index.tsx
@@ -154,7 +154,7 @@ export default () => {
             <Flex direction={['column', null, 'row']} justify="space-between">
               <Box mt={6} width="full">
                 {(!mentorMode || !userIsMentor) && (
-                  <StudentContext courses={data} progress={dbCourses} />
+                  <StudentContext courses={data} progress={dbCourses} userIsMentor={userIsMentor} />
                 )}
                 {mentorMode && userIsMentor && <MentorContext courses={data} />}
               </Box>


### PR DESCRIPTION
## Description
Mentors have the ability to complete a course project outside of the course platform. Therefore course completion values for mentors should not be calculated using the project completion rates.

Resolves https://github.com/OpenMined/openmined/issues/122

## Affected Dependencies
N/A

## How has this been tested?
manual testing in dev environment

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
