### PR TITLE
Change document client height to innerHeight

### DIFF
--- a/apps/courses/src/routes/courses/concept/Footer.tsx
+++ b/apps/courses/src/routes/courses/concept/Footer.tsx
@@ -263,7 +263,7 @@ export default ({
     ) {
       const conceptHeight =
         document.documentElement.scrollHeight -
-        document.documentElement.clientHeight;
+        window.innerHeight;
 
       const progress =
         conceptHeight <= 0 ? 100 : (scrollY / conceptHeight) * 100 || 0;


### PR DESCRIPTION
## Description
document.clientHeight works weird in mobile devices. Changing it to window.innerHeight

