### PR TITLE
Mentor should not assign to same review

### DIFF
--- a/apps/courses/src/routes/courses/_firebase.ts
+++ b/apps/courses/src/routes/courses/_firebase.ts
@@ -1,4 +1,4 @@
-import { Course, ProjectAttemptStatus } from '@openmined/shared/types';
+import { Course, ProjectAttemptStatus, CourseProjectSubmission } from '@openmined/shared/types';
 import {
   hasCompletedConcept,
   hasCompletedLesson,
@@ -248,7 +248,7 @@ export const addSubmission = (
   db: firebase.firestore.Firestore,
   uId: string,
   courseId: string,
-  data: any
+  data: CourseProjectSubmission,
 ) => {
   const submission = getSubmissionsRef(db, uId, courseId).doc().id;
   const submissionRef = getSubmissionsRef(db, uId, courseId).doc(submission);
@@ -298,6 +298,7 @@ export const handleAttemptSubmission = async (
       review_content: null,
       review_started_at: null,
       review_ended_at: null,
+      resigned_mentors: {},
     });
 
     // Once that's done, add the submissions to the submissions array on the user's course document

--- a/apps/courses/src/routes/courses/_helpers.ts
+++ b/apps/courses/src/routes/courses/_helpers.ts
@@ -363,9 +363,9 @@ export const useIsMentor = ({
   course: string;
 }): boolean => {
   const db = useFirestore();
-  const dbUserRef = db.collection('users').doc(user.uid);
   const [dbUser, setDbUser] = useState<User>(null);
 
+  const dbUserRef = user ? db.collection('users').doc(user.uid) : null;
   useEffect(() => {
     const fetchUser = async () => {
       setDbUser((await dbUserRef.get()).data() as User);

--- a/libs/shared/types/src/index.ts
+++ b/libs/shared/types/src/index.ts
@@ -118,7 +118,7 @@ export type ProjectAttempt = {
 };
 
 export type CourseProjectSubmission = {
-  id: string;
+  id?: string;
   course: string;
   part: string;
   attempt: string | number;
@@ -130,6 +130,7 @@ export type CourseProjectSubmission = {
   review_content: string | null;
   review_started_at: firebase.firestore.Timestamp | null;
   review_ended_at: firebase.firestore.Timestamp | null;
+  resigned_mentors: { [mentorId: string]: boolean };
 };
 
 export type MentorReviewStatus = 'pending' | 'resigned' | 'reviewed'


### PR DESCRIPTION
## Description
1. Mentors should assign only 1 at a time.
Disable Assign button when there's 1 active review.

2. Mentors should not be assigned to same review he resigned from.
When mentors resign, save it to submission. And when user assign again, filter those resigned submissions.
