### PR TITLE
Redirect to lesson overview page

### DIFF
--- a/apps/courses/src/routes/courses/Header.tsx
+++ b/apps/courses/src/routes/courses/Header.tsx
@@ -96,6 +96,7 @@ export default ({
   title,
   subtitle,
   course,
+  lesson,
   sections,
   noShadow = false,
   noTitle = false,
@@ -284,9 +285,16 @@ export default ({
         onClose={onLeftDrawerClose}
         header={
           <>
-            <Text color="gray.400" mb={1}>
-              {subtitle}
-            </Text>
+            <Link
+              as={RRDLink}
+              to={`/courses/${course}/${lesson}`}
+              textDecoration="none"
+              _hover={{ textDecoration: 'underline' }}
+            >
+              <Text color="gray.400" mb={1}>
+                {subtitle}
+              </Text>
+            </Link>
             <Heading as="span" size="lg" display="block" mb={3}>
               {title}
             </Heading>


### PR DESCRIPTION
## Description
Solution to #154 
![image](https://user-images.githubusercontent.com/24530559/112960266-3df77b00-9112-11eb-935b-e878a22fdb58.png)

The Subtitle on left nav (Lesson 1) is not clickable link and it will redirect to lesson overview page.