### PR TITLE
Add error cover for lesson description

### DIFF
--- a/apps/courses/src/routes/courses/lesson/index.tsx
+++ b/apps/courses/src/routes/courses/lesson/index.tsx
@@ -166,9 +166,11 @@ export default ({
             {title}
           </Heading>
           <Divider my={6} />
-          <Text color="gray.700" mb={6}>
-            {typeof description === 'string' ? description : description()}
-          </Text>
+          {description && (
+            <Text color="gray.700" mb={6}>
+              {typeof description === 'string' ? description : description()}
+            </Text>
+          )}
           {learnHow && (
             <>
               <Heading as="p" size="md" mb={4}>


### PR DESCRIPTION
## Description
lesson description can be undefined if it's not loaded properly. 

Adding error handler for undefined description.