### PR TITLE
Fix Safari infinite-loading and post-login dashboard crash

### DIFF
--- a/apps/courses/src/App.tsx
+++ b/apps/courses/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useLayoutEffect, useEffect } from 'react';
+import React, { useState, useLayoutEffect } from 'react';
 import { Router } from 'react-router-dom';
 import { createBrowserHistory } from 'history';
 import {
@@ -6,7 +6,6 @@ import {
   preloadFirestore,
   preloadFunctions,
   useFirebaseApp,
-  useFirestore,
 } from 'reactfire';
 
 import Routes from './routes';
@@ -14,53 +13,16 @@ import Routes from './routes';
 import Loading from './components/Loading';
 
 import { SuspenseWithPerf } from 'reactfire';
-import useToast, { toastConfig } from './components/Toast';
 
 const history = createBrowserHistory();
 
-const Firebase = () => {
-  const firestore = useFirestore();
-  const toast = useToast();
-
-  useEffect(() => {
-    try {
-      firestore.enablePersistence({ synchronizeTabs: true }).catch((error) => {
-        if (error.code === 'failed-precondition') {
-          toast({
-            ...toastConfig,
-            title: 'Error',
-            description: error.message,
-            status: 'error',
-          });
-        } else if (error.code === 'unimplemented') {
-          toast({
-            ...toastConfig,
-            title: 'Error',
-            description:
-              'This browser is not fully compatible with offline mode. While you do not have to, we suggest you use a different browser.',
-            status: 'error',
-          });
-        } else {
-          toast({
-            ...toastConfig,
-            title: 'Error',
-            description: error.message,
-            status: 'error',
-          });
-        }
-      });
-    } catch (error) {
-      toast({
-        ...toastConfig,
-        title: 'Error',
-        description: error.message,
-        status: 'error',
-      });
-    }
-  }, []);
-
-  return null;
-};
+// NOTE: Firestore offline persistence (`enablePersistence`) is intentionally NOT enabled.
+// In Safari/WebKit its IndexedDB initialization intermittently never settles, and because
+// Firestore queues every read behind persistence init, the app hung forever on the
+// app-wide Suspense loader (the long-standing "infinite loading after login" bug — verified
+// 2026-06-19: `enablePersistence` START with no resolve/reject, zero Listen/channel requests
+// on the wire; disabling it makes reads resolve in ~270ms). `experimentalForceOwningTab` did
+// not cure it. The app reads live from the network and does not rely on offline caching.
 
 const preloadSDKs = (firebaseApp) => {
   Promise.all([
@@ -85,7 +47,6 @@ const preloadSDKs = (firebaseApp) => {
           ssl: false,
           experimentalForceLongPolling: true,
         });
-        firestore().enablePersistence({ experimentalForceOwningTab: true });
       },
     }),
     // TODO: Create a bucket for dev purposes only
@@ -98,6 +59,18 @@ const preloadSDKs = (firebaseApp) => {
     // }),
   ]);
 };
+
+// Real browsers (non-Cypress): force Firestore to use long-polling instead of the default
+// streaming WebChannel. This is a Safari/WebChannel compatibility safety measure and is the
+// transport configuration validated working in Safari (2026-06-19). It is NOT the fix for
+// the infinite-loading bug — that was offline persistence (see note above).
+const preloadProdFirestore = (firebaseApp) =>
+  preloadFirestore({
+    firebaseApp,
+    setup: (firestore) => {
+      firestore().settings({ experimentalForceLongPolling: true });
+    },
+  });
 
 const App = () => {
   const [action, setAction] = useState(history.action);
@@ -115,12 +88,13 @@ const App = () => {
   // @ts-ignore
   if (window.Cypress) {
     preloadSDKs(firebaseApp);
+  } else {
+    preloadProdFirestore(firebaseApp);
   }
 
   return (
     <Router action={action} location={location} navigator={history}>
       <SuspenseWithPerf fallback={<Loading />} traceId={location.pathname}>
-        <Firebase />
         <Routes />
       </SuspenseWithPerf>
     </Router>

--- a/apps/courses/src/components/AuthReady.tsx
+++ b/apps/courses/src/components/AuthReady.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useState } from 'react';
+import { useUser } from 'reactfire';
+
+import Loading from './Loading';
+
+// After sign-in, Firebase can attach a Firestore listener before the freshly-issued ID
+// token has been wired into Firestore's connection. The first authed read then races the
+// token and the server returns `permission-denied` (e.g. the dashboard's
+// users/{uid}/courses listener). reactfire caches that error for the query, so the app
+// crashes through the Suspense/error boundary and only a full page reload recovers. This
+// gate waits for the ID token to be available before rendering authed content, so the
+// listener attaches with auth.
+//
+// Self-gating: with no logged-in user it renders children immediately (public pages need
+// no token). We prime once per uid (module-scoped) so this only blocks the first authed
+// render after a fresh load/login, not every in-app navigation. A full reload re-primes.
+let primedUid = null;
+
+const AuthReady = ({ children }) => {
+  const user: firebase.User = useUser();
+  const uid = user ? user.uid : null;
+  const [ready, setReady] = useState(!uid || primedUid === uid);
+
+  useEffect(() => {
+    if (!uid) {
+      // Logged out: forget the prime so a re-login (even same tab, same user,
+      // no page reload) re-runs the gate and waits for the new token.
+      primedUid = null;
+      setReady(true);
+      return;
+    }
+    if (primedUid === uid) {
+      setReady(true);
+      return;
+    }
+    let active = true;
+    setReady(false);
+    user
+      .getIdToken()
+      .then(() => {
+        primedUid = uid;
+        if (active) setReady(true);
+      })
+      .catch(() => {
+        // Don't block the UI if the token fetch itself fails; let the normal flow run.
+        primedUid = uid;
+        if (active) setReady(true);
+      });
+    return () => {
+      active = false;
+    };
+  }, [uid, user]);
+
+  if (!ready) return <Loading />;
+
+  return <>{children}</>;
+};
+
+export default AuthReady;

--- a/apps/courses/src/components/Header.tsx
+++ b/apps/courses/src/components/Header.tsx
@@ -202,14 +202,13 @@ export default ({ noScrolling }) => {
               onClick={() =>
                 auth
                   .signOut()
-                  .then(() =>
-                    toast({
-                      ...toastConfig,
-                      title: 'Sign out successful',
-                      description: 'Come back soon!',
-                      status: 'success',
-                    })
-                  )
+                  // Full reload on logout: clears reactfire's global query-observable
+                  // cache (keyed by path, never evicted) and the auth-ready prime, so a
+                  // re-login is a clean cold load instead of reusing a stale
+                  // users/{uid}/courses observable that crashes on same-user re-login.
+                  .then(() => {
+                    window.location.assign('/');
+                  })
                   .catch((error) => handleErrors(toast, error))
               }
             >

--- a/apps/courses/src/routes/courses/Header.tsx
+++ b/apps/courses/src/routes/courses/Header.tsx
@@ -144,14 +144,13 @@ export default ({
       onClick: () =>
         auth
           .signOut()
-          .then(() =>
-            toast({
-              ...toastConfig,
-              title: 'Sign out successful',
-              description: 'Come back soon!',
-              status: 'success',
-            })
-          )
+          // Full reload on logout: clears reactfire's global query-observable cache
+          // (keyed by path, never evicted) and the auth-ready prime, so a re-login is a
+          // clean cold load instead of reusing a stale users/{uid}/courses observable
+          // that crashes on same-user re-login.
+          .then(() => {
+            window.location.assign('/');
+          })
           .catch((error) => handleErrors(toast, error)),
     },
   ];

--- a/apps/courses/src/routes/index.tsx
+++ b/apps/courses/src/routes/index.tsx
@@ -6,6 +6,7 @@ import { Box } from '@chakra-ui/react';
 
 import Header from '../components/Header';
 import Footer from '../components/Footer';
+import AuthReady from '../components/AuthReady';
 
 import Homepage from './homepage';
 import Signup from './users/sign-up';
@@ -43,7 +44,7 @@ const RouteWrapper = ({
       display="grid"
       gridTemplateRows={!noFooter ? '1fr' : '1fr auto'}
     >
-      {children}
+      <AuthReady>{children}</AuthReady>
       {!noFooter && <Footer />}
     </Box>
   </>


### PR DESCRIPTION
## Summary
Fixes two long-standing issues in the Courses app, both diagnosed and validated against production Firestore on an isolated Firebase Hosting preview channel.

### 1. Safari infinite loading after login
Firestore offline persistence (`enablePersistence` → IndexedDB) intermittently never initializes in Safari/WebKit. Because Firestore queues every read behind persistence init, the app hung forever on the app-wide Suspense loader (Chrome's IndexedDB is unaffected). `experimentalForceOwningTab` did not cure it.

**Fix:** remove `enablePersistence` (prod + Cypress paths); keep `experimentalForceLongPolling` for real browsers. The app reads live from the network and does not rely on offline caching. Reads now resolve in ~270ms instead of never settling.

### 2. Intermittent `permission-denied` crash on the dashboard after login
After sign-in, Firestore could attach the dashboard's `users/{uid}/courses` listener before the freshly-issued ID token reached its connection, producing an intermittent `permission-denied` that reactfire caches and throws to the error boundary (full-page crash; a reload recovers).

**Fix:** an `AuthReady` gate that waits for `getIdToken()` before rendering authed content (wired via `RouteWrapper`). Same-user re-login in the same tab also reused reactfire's never-evicted global query-observable cache (keyed by path); logout now does a full reload, clearing that cache and the prime so re-login is a clean cold load.

## Testing
Validated on a preview channel against prod Firestore across fresh-tab and same-tab logout/login in Chrome and Safari: no hangs, no crashes.

## Note
Already deployed to production via a direct hosting deploy (auto-deploy from master has been broken since ~2021). This PR brings the source on `master` in line with what is live. `dev` is currently behind `master` and can be fast-forwarded separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)